### PR TITLE
Design/22 header 초안 제작, 전역 컨테이너 스타일 지정

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,8 +1,14 @@
 <script setup lang="ts">
+import Header from './components/Header.vue';
 </script>
 
 <template>
-  <RouterView></RouterView>
+  <div class="flex flex-row justify-center min-h-screen">
+    <div class="mx-auto w-screen-orridle">
+      <Header></Header>
+      <RouterView></RouterView>
+    </div>
+  </div>
 </template>
 
 <style scoped>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,0 +1,22 @@
+<template>
+  <header class="w-full">
+    <nav class="flex items-center justify-between p-4 bg-orange-400">
+      <a href="/" class="text-lg font-bold">Logo</a>
+      <!-- 네비게이션 링크 추가 위치 -->
+      <div>
+        <a href="/login" class="px-4 py-2 rounded hover:bg-gray-100">로그인</a>
+        <a href="/signup" class="px-4 py-2 rounded hover:bg-gray-100"
+          >회원가입</a
+        >
+      </div>
+    </nav>
+  </header>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'Header',
+});
+</script>

--- a/src/components/HelloWorld.vue
+++ b/src/components/HelloWorld.vue
@@ -1,5 +1,4 @@
-<!-- TODO: 여기서 소셜로그인 작업하기 -->
-
+<!-- TODO: 추후 이 파일 삭제 -->
 <script setup lang="ts">
 import { ref } from 'vue';
 import { RouterLink } from 'vue-router';

--- a/src/style.css
+++ b/src/style.css
@@ -20,6 +20,14 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
+/* 받아온 디자인의 최대 너비인 1440px이 넘어가면 화면 중앙정렬시키기 */
+@media (width > 1440px) {
+  :root {
+    display: flex;
+    justify-content: center;
+  }
+}
+
 body {
   margin: 0;
   display: flex;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,11 @@
 export default {
   content: ['./index.html', './src/**/*.{vue,js,ts,jsx,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      width: {
+        'screen-orridle': '1440px',
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
- 피그마 디자인 대로 반응형 적용 X
- 전역 스타일로 1440px 유지하되 그 이상으로 넘어가면 컨테이너의 중앙배치
- 헤더 초안 제작
<img width="1512" alt="스크린샷 2024-02-07 오후 3 47 28" src="https://github.com/Team-Oriddle/orridle-frontend/assets/54524378/5151bd29-4fe0-4343-9a99-82c0dab3acc5">

<img width="1512" alt="스크린샷 2024-02-07 오후 3 47 41" src="https://github.com/Team-Oriddle/orridle-frontend/assets/54524378/64ebecb1-b28e-4199-b316-62ea256c0aac">

<img width="1512" alt="스크린샷 2024-02-07 오후 3 47 49" src="https://github.com/Team-Oriddle/orridle-frontend/assets/54524378/5922602c-7eb1-458c-9c0c-32e5ef51c673">

